### PR TITLE
Remove ability to have identical ISBN numbers

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ This is a small, HTML and Vanilla JS, app that allows a user to add/save certain
 * A user can add a book to their local storage and view it in the UI
 * A user receives an error message if all the fields for adding a book are not complete
 * A user receives a success message when a book is deleted/added 
+* No 2 ISBN numbers can be the same
 
 
 ## Notable Technologies/Functions/Methods
@@ -39,7 +40,6 @@ This is a small, HTML and Vanilla JS, app that allows a user to add/save certain
 
 ## Future Implementation(s)
 
-* Make sure 2 ISBN numbers are not the same 
 * Make sure an ISBN number is ONLY numbers 
 * Make a GET Req to retrieve books from an API
 * User account 

--- a/app.js
+++ b/app.js
@@ -80,22 +80,22 @@ document.querySelector('#book-form').addEventListener('submit', (e) => {
   e.preventDefault();
   const title = document.querySelector('#title').value;
   const author = document.querySelector('#author').value;
-  const isbn = document.querySelector('#isbn').value;
-  const oldBooks = Store.getBooks();
+  const newISBN = document.querySelector('#isbn').value;
+  const booksInStorage = Store.getBooks();
   const isbnList = [];
 
-  oldBooks.map((singleBook) => {
+  booksInStorage.map((singleBook) => {
     isbnList.push(singleBook.isbn);
   });
 
   if(title === '' || author === '' || isbn === '') {
     UI.showAlert('Please fill in all fields', 'danger');
   }
-  else if(isbnList.includes(isbn)) {
+  else if(isbnList.includes(newISBN)) {
     UI.showAlert('This ISBN is already being used', 'danger');
   }
   else {
-    const book = new Book(title, author, isbn);
+    const book = new Book(title, author, newISBN);
     UI.addBookToList(book);
     Store.addBook(book);
     UI.showAlert('Book successfully added', 'success');

--- a/app.js
+++ b/app.js
@@ -88,7 +88,7 @@ document.querySelector('#book-form').addEventListener('submit', (e) => {
     isbnList.push(singleBook.isbn);
   });
 
-  if(title === '' || author === '' || isbn === '') {
+  if(title === '' || author === '' || newISBN === '') {
     UI.showAlert('Please fill in all fields', 'danger');
   }
   else if(isbnList.includes(newISBN)) {

--- a/app.js
+++ b/app.js
@@ -81,9 +81,18 @@ document.querySelector('#book-form').addEventListener('submit', (e) => {
   const title = document.querySelector('#title').value;
   const author = document.querySelector('#author').value;
   const isbn = document.querySelector('#isbn').value;
+  const oldBooks = Store.getBooks();
+  const isbnList = [];
+
+  oldBooks.map((singleBook) => {
+    isbnList.push(singleBook.isbn);
+  });
 
   if(title === '' || author === '' || isbn === '') {
     UI.showAlert('Please fill in all fields', 'danger');
+  }
+  else if(isbnList.includes(isbn)) {
+    UI.showAlert('This ISBN is already being used', 'danger');
   }
   else {
     const book = new Book(title, author, isbn);


### PR DESCRIPTION
### Status
- Ready


### Description
- The goal of this PR is to remove the ability for 2 ISBN numbers to be the exact same


### Process
- Get the books in local storage (which are in an array)
- Map through the books and push their ISBN numbers into an `isbnList` array
- Add an `else if` that checks to see if the `newISBN` (from the user) is included in the `isbnList` 
- If it's included, an error is thrown and the book is not saved, otherwise the book is saved


### Todos
- [x] Test(s)
- [x] Update Documentation


### Steps to Test
- Create 1 book
- Attempt to create a second book, using the same ISBN number, and see if you receive an error 